### PR TITLE
Feature/101 incorporate cpi in benchmark calculation

### DIFF
--- a/backend/db/crud_living_income_benchmark.py
+++ b/backend/db/crud_living_income_benchmark.py
@@ -51,15 +51,27 @@ def get_by_country_region_year(
         ).first()
         # get CPI from lastest year
         last_year_cpi = cpi.order_by(Cpi.year.desc()).first()
+        # add CPI value
         if case_year_cpi:
+            # Calculate CPI factor
+            # CPI Factor logic
+            case_year_cpi_value = case_year_cpi.value if case_year_cpi else 0
+            last_year_cpi_value = last_year_cpi.value if last_year_cpi else 0
+            # (Latest  Year CPI - Case year CPI)/(Case Year CPI) = CPI factor
+            cpi_factor = (
+                last_year_cpi_value - case_year_cpi_value
+            ) / case_year_cpi_value
+            #
             lib = lib.serialize
             lib["year"] = year
-            lib["case_year_cpi"] = case_year_cpi.value
-            lib["last_year_cpi"] = last_year_cpi.value
+            lib["case_year_cpi"] = case_year_cpi_value
+            lib["last_year_cpi"] = last_year_cpi_value
+            lib["cpi_factor"] = cpi_factor
             return lib
     else:
         lib = lib.serialize
         lib["case_year_cpi"] = None
         lib["last_year_cpi"] = None
+        lib["cpi_factor"] = None
         return lib
     return None

--- a/backend/db/crud_living_income_benchmark.py
+++ b/backend/db/crud_living_income_benchmark.py
@@ -27,6 +27,7 @@ def get_by_country_region_year(
         .first()
     )
     if not lib:
+        # get LI benchmark from last year
         lib = (
             session.query(LivingIncomeBenchmark)
             .filter(
@@ -35,6 +36,7 @@ def get_by_country_region_year(
                     LivingIncomeBenchmark.region == region,
                 )
             )
+            .order_by(LivingIncomeBenchmark.year.desc())
             .first()
         )
         if not lib:

--- a/backend/db/crud_living_income_benchmark.py
+++ b/backend/db/crud_living_income_benchmark.py
@@ -27,7 +27,7 @@ def get_by_country_region_year(
         .first()
     )
     if not lib:
-        # get LI benchmark from last year
+        # get LI benchmark from lastest year
         lib = (
             session.query(LivingIncomeBenchmark)
             .filter(
@@ -41,23 +41,25 @@ def get_by_country_region_year(
         )
         if not lib:
             return None
-        cpi = (
-            session.query(Cpi)
-            .filter(
-                and_(
-                    Cpi.country == country,
-                    Cpi.year == year,
-                )
-            )
-            .first()
+        # get CPI by country
+        cpi = session.query(Cpi).filter(
+            Cpi.country == country,
         )
-        if cpi:
+        # get CPI by case year
+        case_year_cpi = cpi.filter(
+            Cpi.year == year,
+        ).first()
+        # get CPI from lastest year
+        last_year_cpi = cpi.order_by(Cpi.year.desc()).first()
+        if case_year_cpi:
             lib = lib.serialize
             lib["year"] = year
-            lib["cpi"] = cpi.value
+            lib["case_year_cpi"] = case_year_cpi.value
+            lib["last_year_cpi"] = last_year_cpi.value
             return lib
     else:
         lib = lib.serialize
-        lib["cpi"] = None
+        lib["case_year_cpi"] = None
+        lib["last_year_cpi"] = None
         return lib
     return None

--- a/backend/models/living_income_benchmark.py
+++ b/backend/models/living_income_benchmark.py
@@ -20,7 +20,8 @@ class LivingIncomeBenchmarkDict(TypedDict):
     household_size: float
     year: int
     value: LivingIncomeBenchmarkValue
-    cpi: Optional[float]
+    case_year_cpi: Optional[float]
+    last_year_cpi: Optional[float]
 
 
 class LivingIncomeBenchmark(Base):
@@ -74,7 +75,8 @@ class LivingIncomeBenchmark(Base):
                 "usd": self.usd,
                 "eur": self.eur,
             },
-            "cpi": None,
+            "case_year_cpi": None,
+            "last_year_cpi": None,
         }
 
 

--- a/backend/models/living_income_benchmark.py
+++ b/backend/models/living_income_benchmark.py
@@ -22,6 +22,7 @@ class LivingIncomeBenchmarkDict(TypedDict):
     value: LivingIncomeBenchmarkValue
     case_year_cpi: Optional[float]
     last_year_cpi: Optional[float]
+    cpi_factor: Optional[float]
 
 
 class LivingIncomeBenchmark(Base):

--- a/backend/tests/test_000_main.py
+++ b/backend/tests/test_000_main.py
@@ -37,7 +37,7 @@ def test_read_main():
     assert response.status_code == 200
 
 
-class TestAddMasterDataWithoutDedenpentToUser():
+class TestAddMasterDataWithoutDedenpentToUser:
     @pytest.mark.asyncio
     async def test_add_business_unit_master_data(
         self, app: FastAPI, session: Session, client: AsyncClient
@@ -47,7 +47,7 @@ class TestAddMasterDataWithoutDedenpentToUser():
             {"name": "Global Marketing Solutions"},
             {"name": "Finance and Accounting Services, Inc."},
             {"name": "Human Resources and Talent Management"},
-            {"name": "Research and Development Labs"}
+            {"name": "Research and Development Labs"},
         ]
         for val in payload:
             business_unit = BusinessUnit(name=val["name"])
@@ -62,28 +62,27 @@ class TestAddMasterDataWithoutDedenpentToUser():
             {"id": 2, "name": "Global Marketing Solutions"},
             {"id": 3, "name": "Finance and Accounting Services, Inc."},
             {"id": 4, "name": "Human Resources and Talent Management"},
-            {"id": 5, "name": "Research and Development Labs"}
+            {"id": 5, "name": "Research and Development Labs"},
         ]
 
     @pytest.mark.asyncio
     async def test_add_commodity_categories_and_commodities_master_data(
         self, app: FastAPI, session: Session, client: AsyncClient
     ) -> None:
-        payload = [{
-            "name": "Grains",
-            "children": [
-                {"name": "Wheat"},
-                {"name": "Rice"},
-                {"name": "Corn"}
-            ]
-        }, {
-            "name": "Nuts",
-            "children": [
-                {"name": "Almonds"},
-                {"name": "Walnuts"},
-                {"name": "Pecans"}
-            ]
-        }]
+        payload = [
+            {
+                "name": "Grains",
+                "children": [{"name": "Wheat"}, {"name": "Rice"}, {"name": "Corn"}],
+            },
+            {
+                "name": "Nuts",
+                "children": [
+                    {"name": "Almonds"},
+                    {"name": "Walnuts"},
+                    {"name": "Pecans"},
+                ],
+            },
+        ]
         for val in payload:
             commodity_category = CommodityCategory(name=val["name"])
             for child in val["children"]:
@@ -97,51 +96,35 @@ class TestAddMasterDataWithoutDedenpentToUser():
         commodity_categories = [
             val.serialize_with_commodities for val in commodity_categories
         ]
-        assert commodity_categories == [{
-            'id': 1,
-            'name': 'Grains',
-            'commodities': [{
-                'id': 1,
-                'name': 'Wheat'
-            }, {
-                'id': 2,
-                'name': 'Rice'
-            }, {
-                'id': 3,
-                'name': 'Corn'
-            }]
-        }, {
-            'id': 2,
-            'name': 'Nuts',
-            'commodities': [{
-                'id': 4,
-                'name': 'Almonds'
-            }, {
-                'id': 5,
-                'name': 'Walnuts'
-            }, {
-                'id': 6,
-                'name': 'Pecans'
-            }]
-        }]
+        assert commodity_categories == [
+            {
+                "id": 1,
+                "name": "Grains",
+                "commodities": [
+                    {"id": 1, "name": "Wheat"},
+                    {"id": 2, "name": "Rice"},
+                    {"id": 3, "name": "Corn"},
+                ],
+            },
+            {
+                "id": 2,
+                "name": "Nuts",
+                "commodities": [
+                    {"id": 4, "name": "Almonds"},
+                    {"id": 5, "name": "Walnuts"},
+                    {"id": 6, "name": "Pecans"},
+                ],
+            },
+        ]
 
     @pytest.mark.asyncio
     async def test_add_country_master_data(
         self, app: FastAPI, session: Session, client: AsyncClient
     ) -> None:
-        payload = [{
-            "name": "Indonesia",
-            "children": [
-                {"name": "Bali"},
-                {"name": "Lombok"}
-            ]
-        }, {
-            "name": "India",
-            "children": [
-                {"name": "Delhi"},
-                {"name": "Mumbai"}
-            ]
-        }]
+        payload = [
+            {"name": "Indonesia", "children": [{"name": "Bali"}, {"name": "Lombok"}]},
+            {"name": "India", "children": [{"name": "Delhi"}, {"name": "Mumbai"}]},
+        ]
         for val in payload:
             country = Country(name=val["name"])
             for child in val["children"]:
@@ -151,52 +134,43 @@ class TestAddMasterDataWithoutDedenpentToUser():
             session.commit()
             session.flush()
             session.refresh(country)
-        countries = session.query(Country).filter(
-            Country.parent.is_(None)).all()
+        countries = session.query(Country).filter(Country.parent.is_(None)).all()
         countries = [c.serialize for c in countries]
-        assert countries == [{
-            'id': 1,
-            'parent': None,
-            'name': 'Indonesia',
-            'children': [{
-                'id': 2,
-                'parent': 1,
-                'name': 'Bali',
-                'children': []
-            }, {
-                'id': 3,
-                'parent': 1,
-                'name': 'Lombok',
-                'children': []
-            }]
-        }, {
-            'id': 4,
-            'parent': None,
-            'name': 'India',
-            'children': [{
-                'id': 5,
-                'parent': 4,
-                'name': 'Delhi',
-                'children': []
-            }, {
-                'id': 6,
-                'parent': 4,
-                'name': 'Mumbai',
-                'children': []
-            }]
-        }]
+        assert countries == [
+            {
+                "id": 1,
+                "parent": None,
+                "name": "Indonesia",
+                "children": [
+                    {"id": 2, "parent": 1, "name": "Bali", "children": []},
+                    {"id": 3, "parent": 1, "name": "Lombok", "children": []},
+                ],
+            },
+            {
+                "id": 4,
+                "parent": None,
+                "name": "India",
+                "children": [
+                    {"id": 5, "parent": 4, "name": "Delhi", "children": []},
+                    {"id": 6, "parent": 4, "name": "Mumbai", "children": []},
+                ],
+            },
+        ]
 
     @pytest.mark.asyncio
     async def test_add_region_master_data(
         self, app: FastAPI, session: Session, client: AsyncClient
     ) -> None:
-        payload = [{
-            "id": 1,
-            "name": "Rural",
-        }, {
-            "id": 2,
-            "name": "Urban",
-        }]
+        payload = [
+            {
+                "id": 1,
+                "name": "Rural",
+            },
+            {
+                "id": 2,
+                "name": "Urban",
+            },
+        ]
         for val in payload:
             region = Region(id=val["id"], name=val["name"])
             session.add(region)
@@ -205,28 +179,32 @@ class TestAddMasterDataWithoutDedenpentToUser():
             session.refresh(region)
         regions = session.query(Region).all()
         regions = [c.serialize for c in regions]
-        assert regions == [{
-            'id': 1,
-            'name': 'Rural',
-        }, {
-            'id': 2,
-            'name': 'Urban',
-        }]
+        assert regions == [
+            {
+                "id": 1,
+                "name": "Rural",
+            },
+            {
+                "id": 2,
+                "name": "Urban",
+            },
+        ]
         # add country region
-        payload = [{
-            'id': 1,
-            'region': 1,
-            'country': 1,
-        }, {
-            'id': 2,
-            'region': 1,
-            'country': 4,
-        }]
+        payload = [
+            {
+                "id": 1,
+                "region": 1,
+                "country": 1,
+            },
+            {
+                "id": 2,
+                "region": 1,
+                "country": 4,
+            },
+        ]
         for val in payload:
             country_region = CountryRegion(
-                id=val["id"],
-                country=val["country"],
-                region=val["region"]
+                id=val["id"], country=val["country"], region=val["region"]
             )
             session.add(country_region)
             session.commit()
@@ -239,27 +217,30 @@ class TestAddMasterDataWithoutDedenpentToUser():
     async def test_add_benchmark_n_region_master_data(
         self, app: FastAPI, session: Session, client: AsyncClient
     ) -> None:
-        payload = [{
-            "id": 1,
-            "country": 1,
-            "region": 1,
-            "household_size": 4,
-            "year": 2020,
-            "source": "www.akvo.org",
-            "lcu": 1200.50,
-            "usd": 2200.50,
-            "eur": 3200.50,
-        }, {
-            "id": 2,
-            "country": 4,
-            "region": 1,
-            "household_size": 5,
-            "year": 2020,
-            "source": "www.akvo.org",
-            "lcu": 1000,
-            "usd": 2000,
-            "eur": 3000,
-        }]
+        payload = [
+            {
+                "id": 1,
+                "country": 1,
+                "region": 1,
+                "household_size": 4,
+                "year": 2020,
+                "source": "www.akvo.org",
+                "lcu": 1200.50,
+                "usd": 2200.50,
+                "eur": 3200.50,
+            },
+            {
+                "id": 2,
+                "country": 4,
+                "region": 1,
+                "household_size": 5,
+                "year": 2020,
+                "source": "www.akvo.org",
+                "lcu": 1000,
+                "usd": 2000,
+                "eur": 3000,
+            },
+        ]
         for val in payload:
             lib = LivingIncomeBenchmark(
                 id=val["id"],
@@ -278,43 +259,49 @@ class TestAddMasterDataWithoutDedenpentToUser():
             session.refresh(lib)
         libs = session.query(LivingIncomeBenchmark).all()
         libs = [lib.serialize for lib in libs]
-        assert libs == [{
-            'id': 1,
-            'country': 1,
-            'region': 1,
-            'year': 2020,
-            'household_size': 4.0,
-            'value': {
-                'lcu': 1200.5,
-                'usd': 2200.5,
-                'eur': 3200.5
+        assert libs == [
+            {
+                "id": 1,
+                "country": 1,
+                "region": 1,
+                "year": 2020,
+                "household_size": 4.0,
+                "value": {"lcu": 1200.5, "usd": 2200.5, "eur": 3200.5},
+                "case_year_cpi": None,
+                "last_year_cpi": None,
             },
-            'cpi': None
-        }, {
-            'id': 2,
-            'country': 4,
-            'region': 1,
-            'year': 2020,
-            'household_size': 5.0,
-            'value': {
-                'lcu': 1000.0,
-                'usd': 2000.0,
-                'eur': 3000.0
+            {
+                "id": 2,
+                "country": 4,
+                "region": 1,
+                "year": 2020,
+                "household_size": 5.0,
+                "value": {"lcu": 1000.0, "usd": 2000.0, "eur": 3000.0},
+                "case_year_cpi": None,
+                "last_year_cpi": None,
             },
-            'cpi': None
-        }]
+        ]
         # cpi
-        payload = [{
-            'id': 1,
-            'country': 1,
-            'year': 2020,
-            'value': 5000,
-        }, {
-            'id': 2,
-            'country': 1,
-            'year': 2021,
-            'value': 7000,
-        }]
+        payload = [
+            {
+                "id": 1,
+                "country": 1,
+                "year": 2020,
+                "value": 5000,
+            },
+            {
+                "id": 2,
+                "country": 1,
+                "year": 2021,
+                "value": 6000,
+            },
+            {
+                "id": 3,
+                "country": 1,
+                "year": 2022,
+                "value": 7000,
+            },
+        ]
         for val in payload:
             cpi = Cpi(
                 id=val["id"],
@@ -328,14 +315,8 @@ class TestAddMasterDataWithoutDedenpentToUser():
             session.refresh(cpi)
         cpis = session.query(Cpi).all()
         cpis = [c.serialize for c in cpis]
-        assert cpis == [{
-            'id': 1,
-            'country': 1,
-            'year': 2020,
-            'value': 5000.0
-        }, {
-            'id': 2,
-            'country': 1,
-            'year': 2021,
-            'value': 7000.0
-        }]
+        assert cpis == [
+            {"id": 1, "country": 1, "year": 2020, "value": 5000.0},
+            {"id": 2, "country": 1, "year": 2021, "value": 6000.0},
+            {"id": 3, "country": 1, "year": 2022, "value": 7000.0},
+        ]

--- a/backend/tests/test_070_benchmark.py
+++ b/backend/tests/test_070_benchmark.py
@@ -11,7 +11,7 @@ non_admin_account = Acc(email="support@akvo.org", token=None)
 admin_account = Acc(email="super_admin@akvo.org", token=None)
 
 
-class TestBenchmarkRoute():
+class TestBenchmarkRoute:
     @pytest.mark.asyncio
     async def test_get_benchmark_by_country_region_year_1(
         self, app: FastAPI, session: Session, client: AsyncClient
@@ -22,25 +22,22 @@ class TestBenchmarkRoute():
                 "lib:get_by_country_region_year",
             ),
             params={
-                'country_id': 1,
-                'region_id': 1,
-                'year': 2020,
-            }
+                "country_id": 1,
+                "region_id": 1,
+                "year": 2020,
+            },
         )
         assert res.status_code == 200
         res = res.json()
         assert res == {
-            'id': 1,
-            'country': 1,
-            'region': 1,
-            'household_size': 4,
-            'year': 2020,
-            'value': {
-                'lcu': 1200.5,
-                'usd': 2200.5,
-                'eur': 3200.5
-            },
-            'cpi': None
+            "id": 1,
+            "country": 1,
+            "region": 1,
+            "household_size": 4.0,
+            "year": 2020,
+            "value": {"lcu": 1200.5, "usd": 2200.5, "eur": 3200.5},
+            "case_year_cpi": None,
+            "last_year_cpi": None,
         }
 
     @pytest.mark.asyncio
@@ -53,25 +50,22 @@ class TestBenchmarkRoute():
                 "lib:get_by_country_region_year",
             ),
             params={
-                'country_id': 1,
-                'region_id': 1,
-                'year': 2021,
-            }
+                "country_id": 1,
+                "region_id": 1,
+                "year": 2021,
+            },
         )
         assert res.status_code == 200
         res = res.json()
         assert res == {
-            'id': 1,
-            'country': 1,
-            'region': 1,
-            'household_size': 4,
-            'year': 2021,
-            'value': {
-                'lcu': 1200.5,
-                'usd': 2200.5,
-                'eur': 3200.5
-            },
-            'cpi': 7000.0
+            "id": 1,
+            "country": 1,
+            "region": 1,
+            "household_size": 4.0,
+            "year": 2021,
+            "value": {"lcu": 1200.5, "usd": 2200.5, "eur": 3200.5},
+            "case_year_cpi": 6000.0,
+            "last_year_cpi": 7000.0,
         }
 
     @pytest.mark.asyncio
@@ -84,10 +78,10 @@ class TestBenchmarkRoute():
                 "lib:get_by_country_region_year",
             ),
             params={
-                'country_id': 100,
-                'region_id': 100,
-                'year': 2020,
-            }
+                "country_id": 100,
+                "region_id": 100,
+                "year": 2020,
+            },
         )
         assert res.status_code == 404
 
@@ -101,9 +95,9 @@ class TestBenchmarkRoute():
                 "lib:get_by_country_region_year",
             ),
             params={
-                'country_id': 1,
-                'region_id': 1,
-                'year': 2012,
-            }
+                "country_id": 1,
+                "region_id": 1,
+                "year": 2012,
+            },
         )
         assert res.status_code == 404

--- a/backend/tests/test_070_benchmark.py
+++ b/backend/tests/test_070_benchmark.py
@@ -38,6 +38,7 @@ class TestBenchmarkRoute:
             "value": {"lcu": 1200.5, "usd": 2200.5, "eur": 3200.5},
             "case_year_cpi": None,
             "last_year_cpi": None,
+            "cpi_factor": None,
         }
 
     @pytest.mark.asyncio
@@ -66,6 +67,7 @@ class TestBenchmarkRoute:
             "value": {"lcu": 1200.5, "usd": 2200.5, "eur": 3200.5},
             "case_year_cpi": 6000.0,
             "last_year_cpi": 7000.0,
+            "cpi_factor": 0.16666666666666666,
         }
 
     @pytest.mark.asyncio

--- a/frontend/src/pages/cases/components/IncomeDriverTarget.js
+++ b/frontend/src/pages/cases/components/IncomeDriverTarget.js
@@ -156,10 +156,11 @@ const IncomeDriverTarget = ({
           // Case year LI Benchmark = Latest Benchmark*(1-CPI factor)
           if (data?.cpi_factor) {
             const caseYearLIB = targetValue * (1 - data.cpi_factor);
-            setIncomeTarget(caseYearLIB);
+            const LITarget = (HHSize / targetHH) * caseYearLIB;
+            setIncomeTarget(LITarget);
             updateFormValues({
               ...regionData,
-              target: caseYearLIB,
+              target: LITarget,
               benchmark: data,
             });
           } else {

--- a/frontend/src/pages/cases/components/IncomeDriverTarget.js
+++ b/frontend/src/pages/cases/components/IncomeDriverTarget.js
@@ -15,8 +15,6 @@ const IncomeDriverTarget = ({
   // totalIncome,
 }) => {
   const [form] = Form.useForm();
-  // const [householdSize, setHouseholdSize] = useState(0);
-  // const [benchmark, setBenchmark] = useState(segmentItem?.benchmark || null);
   const [incomeTarget, setIncomeTarget] = useState(0);
   const [disableTarget, setDisableTarget] = useState(true);
   const [regionOptions, setRegionOptions] = useState([]);
@@ -68,24 +66,8 @@ const IncomeDriverTarget = ({
       form.setFieldsValue({
         household_children: segmentItem?.child || null,
       });
-      // const HHSize = calculateHouseholdSize({
-      //   household_adult: segmentItem?.adult || 0,
-      //   household_children: segmentItem?.child || 0,
-      // });
-      // setHouseholdSize(HHSize);
     }
   }, [segmentItem, currentSegmentId, form]);
-
-  // load initial target from segment item instead of recalculated (above useEffect)
-  // useEffect(() => {
-  //   if (benchmark && !isEmpty(benchmark)) {
-  //     const targetValue =
-  //       benchmark.value?.[currentCase.currency.toLowerCase()] ||
-  //       benchmark.value.lcu;
-  //     const targetHH = (householdSize / benchmark.household_size) * targetValue;
-  //     setIncomeTarget(targetHH);
-  //   }
-  // }, [benchmark, householdSize, currentCase]);
 
   // call region api
   useEffect(() => {
@@ -118,7 +100,6 @@ const IncomeDriverTarget = ({
   const onValuesChange = (changedValues, allValues) => {
     const { target, region } = allValues;
     const HHSize = calculateHouseholdSize(allValues);
-    // setHouseholdSize(HHSize);
     // eslint-disable-next-line no-undefined
     if (changedValues.manual_target !== undefined) {
       // manual target
@@ -151,7 +132,6 @@ const IncomeDriverTarget = ({
           const targetHH = data.household_size;
           const targetValue =
             data.value?.[currentCase.currency.toLowerCase()] || data.value.lcu;
-          // setBenchmark(data);
           // with CPI calculation
           // Case year LI Benchmark = Latest Benchmark*(1-CPI factor)
           if (data?.cpi_factor) {


### PR DESCRIPTION
### TODO / DONE

---

- #101 
- [x] Update BE, living income benchmark endpoint to provide the correct CPI value
- [x] Update BE, provide CPI factor value for FE calculation
- [x] Update FE, incorporate CPI value in LI benchmark calculation
- [x] Update FE, load target initial value from segment target instead of recalculate inside useEffect hook

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205937582633980