### PR TITLE
Add redirect Nginx config

### DIFF
--- a/frontend/nginx/conf.d/default.conf
+++ b/frontend/nginx/conf.d/default.conf
@@ -18,9 +18,17 @@ gzip_types
 proxy_cache_path    /var/tmp/cache levels=1:2 keys_zone=STATIC:10m inactive=24h;
 
 server {
-    listen       80;
-    listen  [::]:80;
-    server_name  localhost;
+    listen 80;
+    server_name incomedrivercalculator.idhtrade.org;
+
+    # Redirect all requests to incometoolkit.idhtrade.org
+    return 301 https://incometoolkit.idhtrade.org$request_uri;
+}
+
+server {
+    listen       80 default_server;
+    listen  [::]:80 default_server;
+    server_name "";
     root   /usr/share/nginx/html;
 
     if ($http_x_forwarded_proto = "http") {


### PR DESCRIPTION
Traffic to https://incomedrivercalculator.idhtrade.org/ should redirected to https://incometoolkit.idhtrade.org/