### PR TITLE
[#776] ROI Input Box Guidance & Default Expansion

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -16,6 +16,14 @@ Income Driver Calculator (IDC) is a web application designed to help companies t
 - **CI/CD**: Automated deployment to test cluster on push to `main`.
 
 ## Recent Changes
+- **ROI Input Box Guidance & Default Expansion (#776) - [COMPLETED]**:
+        - Refactored `ScenarioModelingROIForm.js` and `case_ui.js` to ensure the ROI component modeling section is expanded by default when cost allocation is enabled.
+        - Implemented an instructional info box in Step 5 to guide users on net cost inputs (fixed/variable costs vs. potential revenue).
+        - Migrated ROI info box styles from inline JSX to a dedicated `ScenarioModelingROIForm.scss` file for better maintainability.
+        - Standardized info box text to black for improved contrast and IDC brand alignment.
+        - Refined toggle handlers to ensure robust expansion/collapse behavior across segment switches and mode changes.
+        - Verified the implementation with a clean `yarn lint` pass and manual logic validation.
+    - Path: `frontend/src/pages/cases/components/ScenarioModelingROIForm.js`, `frontend/src/pages/cases/components/ScenarioModelingROIForm.scss`, `frontend/src/pages/cases/store/case_ui.js`.
 - **Step 5 Chart Inconsistency & Stability Fix (#774) - [COMPLETED]**:
         - Resolved a bug in Step 5 where chart baseline values fluctuated incorrectly when navigating between segment tabs.
         - Refactored `backwardScenarioData` in `ScenarioModelingIncomeDriversAndChart.js` to correctly resolve segment-specific baseline data during synchronization.

--- a/frontend/src/pages/cases/components/ScenarioModelingROIForm.js
+++ b/frontend/src/pages/cases/components/ScenarioModelingROIForm.js
@@ -319,17 +319,35 @@ const ScenarioModelingROIForm = ({
           </Form.Item>
         </Col>
       </Row>
-
       {(costAllocationMode === "per_segment" ||
         costAllocationMode === "all_farmers") && (
-        <Row
-          align="middle"
-          justify="space-between"
-          style={{
-            padding: "20px 0",
-            borderTop: "1px solid #f0f0f0",
-          }}
-        >
+        <>
+          <div
+            style={{
+              background: "#eaf2f2",
+              borderRadius: "12px",
+              padding: "20px",
+              marginTop: "20px",
+              border: "1px solid rgba(27, 98, 95, 0.1)",
+              lineHeight: "1.5",
+            }}
+          >
+            <Text style={{ color: "#26605f" }}>
+              Please input the net cost of implementing the scenario, taking
+              into account all fixed and variable cost as well as the potential
+              revenue created (e.g, farmer payments for trainings). You can
+              either input the total cost of the scenario as a whole, or break
+              it down by component.
+            </Text>
+          </div>
+          <Row
+            align="middle"
+            justify="space-between"
+            style={{
+              padding: "20px 0",
+              borderTop: "1px solid #f0f0f0",
+            }}
+          >
           <Col span={24}>
             <Space direction="vertical" style={{ width: "100%" }}>
               {costAllocationMode === "all_farmers" ? (
@@ -373,7 +391,8 @@ const ScenarioModelingROIForm = ({
               )}
             </Space>
           </Col>
-        </Row>
+          </Row>
+        </>
       )}
 
       <Form.Item

--- a/frontend/src/pages/cases/components/ScenarioModelingROIForm.js
+++ b/frontend/src/pages/cases/components/ScenarioModelingROIForm.js
@@ -25,6 +25,7 @@ import {
   CaretUpOutlined,
   LockOutlined,
 } from "@ant-design/icons";
+import "./ScenarioModelingROIForm.scss";
 
 const { Text } = Typography;
 
@@ -319,20 +320,12 @@ const ScenarioModelingROIForm = ({
           </Form.Item>
         </Col>
       </Row>
+
       {(costAllocationMode === "per_segment" ||
         costAllocationMode === "all_farmers") && (
         <>
-          <div
-            style={{
-              background: "#eaf2f2",
-              borderRadius: "12px",
-              padding: "20px",
-              marginTop: "20px",
-              border: "1px solid rgba(27, 98, 95, 0.1)",
-              lineHeight: "1.5",
-            }}
-          >
-            <Text style={{ color: "#26605f" }}>
+          <div className="roi-instruction-box">
+            <Text>
               Please input the net cost of implementing the scenario, taking
               into account all fixed and variable cost as well as the potential
               revenue created (e.g, farmer payments for trainings). You can
@@ -348,49 +341,49 @@ const ScenarioModelingROIForm = ({
               borderTop: "1px solid #f0f0f0",
             }}
           >
-          <Col span={24}>
-            <Space direction="vertical" style={{ width: "100%" }}>
-              {costAllocationMode === "all_farmers" ? (
-                <Typography.Text strong>
-                  Scenario cost for all farmers
-                </Typography.Text>
-              ) : (
-                <Row
-                  align="middle"
-                  justify="space-between"
-                  style={{ width: "100%" }}
-                >
-                  <Col>
-                    <Typography.Text strong>
-                      Scenario cost for segment
-                    </Typography.Text>
-                  </Col>
-                  <Col>
-                    <Radio.Group
-                      className="roi-segment-selector"
-                      value={activeSegmentId}
-                      onChange={(e) => {
-                        const val = e.target.value;
-                        CaseUIState.update((s) => {
-                          s.general.activeSegmentId = val;
-                        });
-                      }}
-                    >
-                      {orderBy(currentCase.segments, ["id"]).map((seg) => (
-                        <Radio.Button
-                          key={seg.id}
-                          value={seg.id}
-                          style={{ fontWeight: "normal" }}
-                        >
-                          {seg.name}
-                        </Radio.Button>
-                      ))}
-                    </Radio.Group>
-                  </Col>
-                </Row>
-              )}
-            </Space>
-          </Col>
+            <Col span={24}>
+              <Space direction="vertical" style={{ width: "100%" }}>
+                {costAllocationMode === "all_farmers" ? (
+                  <Typography.Text strong>
+                    Scenario cost for all farmers
+                  </Typography.Text>
+                ) : (
+                  <Row
+                    align="middle"
+                    justify="space-between"
+                    style={{ width: "100%" }}
+                  >
+                    <Col>
+                      <Typography.Text strong>
+                        Scenario cost for segment
+                      </Typography.Text>
+                    </Col>
+                    <Col>
+                      <Radio.Group
+                        className="roi-segment-selector"
+                        value={activeSegmentId}
+                        onChange={(e) => {
+                          const val = e.target.value;
+                          CaseUIState.update((s) => {
+                            s.general.activeSegmentId = val;
+                          });
+                        }}
+                      >
+                        {orderBy(currentCase.segments, ["id"]).map((seg) => (
+                          <Radio.Button
+                            key={seg.id}
+                            value={seg.id}
+                            style={{ fontWeight: "normal" }}
+                          >
+                            {seg.name}
+                          </Radio.Button>
+                        ))}
+                      </Radio.Group>
+                    </Col>
+                  </Row>
+                )}
+              </Space>
+            </Col>
           </Row>
         </>
       )}

--- a/frontend/src/pages/cases/components/ScenarioModelingROIForm.js
+++ b/frontend/src/pages/cases/components/ScenarioModelingROIForm.js
@@ -67,10 +67,10 @@ const ScenarioModelingROIForm = ({
 
   const isRoiExpanded = useMemo(() => {
     if (costAllocationMode === "all_farmers") {
-      return isRoiExpandedAll;
+      return isRoiExpandedAll !== false;
     }
     if (costAllocationMode === "per_segment") {
-      return !!isRoiExpandedSegments[segmentId];
+      return isRoiExpandedSegments[segmentId] !== false;
     }
     return false;
   }, [costAllocationMode, isRoiExpandedAll, isRoiExpandedSegments, segmentId]);
@@ -311,7 +311,7 @@ const ScenarioModelingROIForm = ({
                   form?.setFieldsValue({ is_roi_enabled: mode !== "no" });
                 });
                 CaseUIState.update((s) => {
-                  s.general.isRoiExpandedAll = false;
+                  s.general.isRoiExpandedAll = true;
                   s.general.isRoiExpandedSegments = {};
                 });
               }}
@@ -402,10 +402,10 @@ const ScenarioModelingROIForm = ({
                   onClick={() => {
                     CaseUIState.update((s) => {
                       if (costAllocationMode === "all_farmers") {
-                        s.general.isRoiExpandedAll = !isRoiExpandedAll;
+                        s.general.isRoiExpandedAll = !isRoiExpanded;
                       } else if (costAllocationMode === "per_segment") {
                         s.general.isRoiExpandedSegments[segmentId] =
-                          !isRoiExpandedSegments[segmentId];
+                          !isRoiExpanded;
                       }
                     });
                   }}

--- a/frontend/src/pages/cases/components/ScenarioModelingROIForm.scss
+++ b/frontend/src/pages/cases/components/ScenarioModelingROIForm.scss
@@ -1,0 +1,14 @@
+@import "../../../variables.scss";
+
+.roi-instruction-box {
+  background-color: #eaf2f2;
+  border-radius: 12px;
+  padding: 20px;
+  margin-top: 20px;
+  border: 1px solid rgba(1, 98, 95, 0.1);
+  line-height: 1.5;
+
+  .ant-typography {
+    color: #000 !important;
+  }
+}

--- a/frontend/src/pages/cases/store/case_ui.js
+++ b/frontend/src/pages/cases/store/case_ui.js
@@ -7,7 +7,7 @@ const defaultCaseUIState = {
     enableDataUpload: true,
     enableImpactOfInvestment: true,
     activeSegmentId: null,
-    isRoiExpandedAll: false,
+    isRoiExpandedAll: true,
     isRoiExpandedSegments: {},
   },
   caseButton: {


### PR DESCRIPTION
## Summary
This PR enhances the Return on Investment (ROI) modeling UX in Step 5 (Closing the Gap). It ensures that the ROI component table is open by default when cost allocation is enabled, reducing friction for users, and adds an instructional info box to clarify the "Net Cost" entry logic.

## Key Changes
- **Default Expansion**: Updated `CaseUIState` and `ScenarioModelingROIForm.js` to set ROI component box to expanded by default.
- **Toggle Refinement**: Refactored expansion logic to handle `undefined` (default) states correctly, ensuring the first click collapses the box as expected.
- **Instructional Info Box**: Added a styled guide explaining that users should input net costs, including potential revenues (e.g., farmer training fees).
- **CSS Refactoring**: Migrated inline info box styles to `ScenarioModelingROIForm.scss` and standardized text color to black for better contrast.

## Verification
- **Linting**: Verified with `yarn lint` (all checks passed).
- **Manual Review**: 
    - Verified default expansion on segment switch.
    - Verified toggle functionality from both default and manual states.
    - Verified that the info box appears only when ROI modeling is enabled ("All Farmers" or "Per Segment").
    - Verified font color and styling in SCSS.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214049935782078