### PR TITLE
[#774] fix(frontend): resolve Step 5 total income and chart discrepancy

### DIFF
--- a/frontend/src/pages/cases/components/ScenarioModelingIncomeDriversAndChart.js
+++ b/frontend/src/pages/cases/components/ScenarioModelingIncomeDriversAndChart.js
@@ -202,6 +202,16 @@ const ScenarioModelingIncomeDriversAndChart = ({
       });
   }, [incomeDataDrivers]);
 
+  const flattenAllQuestions = useMemo(() => {
+    return questionGroups.flatMap((group) => {
+      const questions = !group ? [] : flatten(group.questions);
+      return questions.map((q) => ({
+        case_commodity: group.id,
+        ...q,
+      }));
+    });
+  }, [questionGroups]);
+
   const calculateChildrenValues = (question, fieldKey, values) => {
     const childrenQuestions = flattenIncomeDataDriversQuestions.filter(
       (q) => q.parent === question?.parent
@@ -229,11 +239,15 @@ const ScenarioModelingIncomeDriversAndChart = ({
     } else {
       const fieldKey = `${fieldName}-${caseCommodityId}`;
 
-      const question = flattenIncomeDataDriversQuestions.find(
-        (q) => q.id === parseInt(questionId)
+      const question = flattenAllQuestions.find(
+        (q) =>
+          q.id === parseInt(questionId) &&
+          q.case_commodity === parseInt(caseCommodityId)
       );
-      const parentQuestion = flattenIncomeDataDriversQuestions.find(
-        (q) => q.id === question?.parent
+      const parentQuestion = flattenAllQuestions.find(
+        (q) =>
+          q.id === question?.parent &&
+          q.case_commodity === parseInt(caseCommodityId)
       );
 
       const allChildrensValues = calculateChildrenValues(
@@ -531,11 +545,11 @@ const ScenarioModelingIncomeDriversAndChart = ({
               : totalIncomeQuestions;
 
           const totalCurrentIncomeAnswer = backwardTotalIncomeQuestions
-            .map((qs) => actualSegment?.answers?.[`current-${qs}`] || 0)
+            .map((qs) => segment?.answers?.[`current-${qs}`] || 0)
             .filter((a) => a)
             .reduce((acc, a) => acc + a, 0);
           const totalFeasibleIncomeAnswer = totalIncomeQuestions
-            .map((qs) => actualSegment?.answers?.[`feasible-${qs}`] || 0)
+            .map((qs) => segment?.answers?.[`feasible-${qs}`] || 0)
             .filter((a) => a)
             .reduce((acc, a) => acc + a, 0);
 
@@ -1093,7 +1107,7 @@ const ScenarioModelingIncomeDriversAndChart = ({
       ) || {};
     const newTotalIncome =
       findScenario?.updatedSegmentScenarioValue?.total_current_income || 0;
-    return Math.round(newTotalIncome);
+    return newTotalIncome;
   }, [segment?.id, backwardScenarioData?.scenarioValues]);
 
   return (


### PR DESCRIPTION
## Description
This PR fixes the issue where "Total Income" values and scenario charts failed to reflect driver changes in Step 5.

## Key Changes
- **Bubbling Fix**: Expanded `recalculate` scope to ensure driver changes bubble up all the way to the "Total Income" target for all commodities.
- **Data Initialization**: Fixed `backwardScenarioData` to correctly map updated scenario answers instead of stale baseline data.
- **Precision**: Standardized both Current and New total income values to show 2 decimal places for better visibility of incremental changes.

## Verification
- Verified that "New" total income updates live when drivers are changed.
- Verified that "Optimal driver values" charts now show correct additional income bars across all segments.