### PR TITLE
[#787] Fix: Compare Income Gap Table Multiplier

### DIFF
--- a/frontend/src/pages/cases/visualizations/CompareIncomeGap.js
+++ b/frontend/src/pages/cases/visualizations/CompareIncomeGap.js
@@ -10,7 +10,7 @@ const CompareIncomeGap = () => {
   const columns = useMemo(() => {
     return [
       {
-        title: "Segment",
+        title: "Segment name",
         dataIndex: "name",
         key: "name",
         width: "30%",
@@ -19,7 +19,7 @@ const CompareIncomeGap = () => {
         title: "Number of farmers",
         dataIndex: "number_of_farmers",
         key: "number_of_farmers",
-        width: "15%",
+        width: "18%",
         align: "center",
       },
       {
@@ -41,18 +41,19 @@ const CompareIncomeGap = () => {
 
   const dataSource = useMemo(() => {
     const res = dashboardData.map((d) => {
+      const numberOfFarmers = d.number_of_farmers || 0;
       const currentIncomeGap =
         d.target - d.total_current_income < 0
           ? 0
-          : d.target - d.total_current_income;
+          : (d.target - d.total_current_income) * numberOfFarmers;
       const feasibleIncomeGap =
         d.target - d.total_feasible_income < 0
           ? 0
-          : d.target - d.total_feasible_income;
+          : (d.target - d.total_feasible_income) * numberOfFarmers;
       return {
         id: d.id,
         name: d.name,
-        number_of_farmers: d.number_of_farmers || 0,
+        number_of_farmers: numberOfFarmers,
         current_income_gap: thousandFormatter(currentIncomeGap, 2),
         feasible_income_gap: thousandFormatter(feasibleIncomeGap, 2),
       };


### PR DESCRIPTION
### Summary
Fixed the "Compare Income Gap" table in Step 3 to accurately calculate and display the total segment income gap by multiplying the per-farmer gap by the number of farmers in that segment.

### Key Changes
- Modified `currentIncomeGap` and `feasibleIncomeGap` calculations to multiply the per-farmer gap by `number_of_farmers`.
- Maintained the existing floor function (`0`) to prevent negative gaps for targets already met.
- Adjusted column dimension and renamed the table column from "Segment" to "Segment name".

### Verification
- Frontend linting (`yarn lint`) passed successfully.
- Code logically matches the IDH formulas for total segment outcome calculation.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214051734845335