### PR TITLE
[#793] feat: update feasible value quantile from 90th to 80th

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -16,6 +16,13 @@ Income Driver Calculator (IDC) is a web application designed to help companies t
 - **CI/CD**: Automated deployment to test cluster on push to `main`.
 
 ## Recent Changes
+- **Feasible Value Quantile Update (#793) - [COMPLETED]**:
+        - Updated the "feasible value" calculation from the 90th quantile to the 80th quantile to better represent achievable improvements.
+        - Modified backend `case_import_process_confirmed_segmentation.py` to use `values.quantile(0.8)`.
+        - Updated frontend `EnterIncomeData.js` tooltip text to reflect the 80th quantile calculation.
+        - Synchronized feature documentation in `CASE_MANAGEMENT_UX.md`.
+    - Path: `backend/utils/case_import_process_confirmed_segmentation.py`, `frontend/src/pages/cases/steps/EnterIncomeData.js`, `docs/features/CASE_MANAGEMENT_UX.md`.
+
 - **ZIP Template Download (#791) - [COMPLETED]**:
         - Updated template download functionality to serve `data_upload_template.zip` instead of `.xlsm`.
         - Modified backend `case_import.py` to use `application/zip` media type and point to the ZIP asset.

--- a/backend/utils/case_import_process_confirmed_segmentation.py
+++ b/backend/utils/case_import_process_confirmed_segmentation.py
@@ -219,7 +219,7 @@ def process_confirmed_segmentation(
                 continue
 
             current_value = float(values.median())
-            feasible_value = float(values.quantile(0.9))
+            feasible_value = float(values.quantile(0.8))
 
             if raw_id and "-" in str(raw_id):
                 level, qid = raw_id.split("-", 1)

--- a/docs/features/CASE_MANAGEMENT_UX.md
+++ b/docs/features/CASE_MANAGEMENT_UX.md
@@ -38,7 +38,7 @@ A standalone script (`backend/cleanup_imports.py`) is provided for administrativ
 ## 4. UI Text & Terminology Updates (#744)
 
 Standardized labels and tooltips have been updated throughout the application to align with business terminology:
-*   **Feasibility Tooltip**: Updated in Step 2 to explain the 90th quantile calculation used to determine "Feasible" values from uploaded data.
+*   **Feasibility Tooltip**: Updated in Step 2 to explain the 80th quantile calculation used to determine "Feasible" values from uploaded data.
 *   **Step 5 Reference**: Changed "physically possible" to "possible" for professional consistency.
 *   **Guidance Tooltips**: Dedicated "?" icons are provided in Step 1 for "Variable type" and "Number of segments".
 

--- a/frontend/src/pages/cases/steps/EnterIncomeData.js
+++ b/frontend/src/pages/cases/steps/EnterIncomeData.js
@@ -324,7 +324,7 @@ const EnterIncomeData = ({
                     <br />
                     If you used the data upload function, the feasible values
                     represent top-performing farmers in your dataset. They are
-                    based on the 90th quantile of each driver.
+                    based on the 80th quantile of each driver.
                   </>
                 }
               >


### PR DESCRIPTION
### Summary
Updated the "feasible value" calculation logic across the stack to use the 80th quantile instead of the 90th. This change ensures that the targets displayed in Step 2 are more realistically achievable for farmer segments based on the uploaded data.

### Key Changes
- **Backend**: Updated `case_import_process_confirmed_segmentation.py` to calculate `feasible_value` using `values.quantile(0.8)`.
- **Frontend**: Updated the tooltip in `EnterIncomeData.js` to inform users that feasibility is now calculated as the 80th quantile.
- **Documentation**: Synchronized `CASE_MANAGEMENT_UX.md` and updated `GEMINI.md`.

### Verification
- **Unit Tests**: Backend unit tests and a targeted mathematical test for `quantile(0.8)` passed.
- **Linting**: Frontend linting (`yarn lint`) passed.
- **Full Check**: Full backend check (`./check.sh`) passed.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214325869658175