### PR TITLE
[#731] feat(frontend): Add read-only alert info for external regular users

### DIFF
--- a/frontend/src/pages/cases/Case.js
+++ b/frontend/src/pages/cases/Case.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { CaseWrapper, SegmentTabsWrapper } from "./layout";
+import { ReadOnlyAlert } from "./components";
 import { useParams, useNavigate } from "react-router-dom";
 import { api, flatten, getFunctionDefaultValue } from "../../lib";
 import {
@@ -55,16 +56,21 @@ const addLevelIntoQuestions = ({ questions, level = 0 }) => {
   });
 };
 
-const renderPage = (key, navigate) => {
+const renderPage = (key, navigate, isExternalRegular) => {
   switch (key) {
     case stepPath.step1.label:
       return (
-        <SegmentTabsWrapper
-          titleId="set-income-target"
-          pageTitle="Set an income target"
-        >
-          <SetIncomeTarget />
-        </SegmentTabsWrapper>
+        <>
+          {isExternalRegular && (
+            <ReadOnlyAlert style={{ marginBottom: "24px" }} />
+          )}
+          <SegmentTabsWrapper
+            titleId="set-income-target"
+            pageTitle="Set an income target"
+          >
+            <SetIncomeTarget />
+          </SegmentTabsWrapper>
+        </>
       );
     case stepPath.step2.label:
       return (
@@ -98,6 +104,7 @@ const Case = () => {
     CaseVisualState.useState((s) => s);
 
   const userState = UserState.useState((s) => s);
+  const isExternalRegular = userState?.isExternalRegular || false;
   useScenarioCalculations();
 
   const updateStepIncomeTargetState = (key, value) => {
@@ -678,7 +685,7 @@ const Case = () => {
       currentCase={currentCase}
       loading={loading}
     >
-      {renderPage(step, navigate)}
+      {renderPage(step, navigate, isExternalRegular)}
     </CaseWrapper>
   );
 };

--- a/frontend/src/pages/cases/components/ReadOnlyAlert.js
+++ b/frontend/src/pages/cases/components/ReadOnlyAlert.js
@@ -1,0 +1,56 @@
+import React from "react";
+import { Alert } from "antd";
+import { InfoCircleOutlined } from "@ant-design/icons";
+
+const ReadOnlyAlert = ({ style = {} }) => {
+  return (
+    <Alert
+      type="info"
+      showIcon
+      icon={
+        <InfoCircleOutlined
+          style={{
+            color: "#0098FF",
+            fontSize: "22px",
+          }}
+        />
+      }
+      message={
+        <span
+          style={{
+            fontWeight: 700,
+            fontSize: "14px",
+            color: "#000",
+            marginBottom: 0,
+          }}
+        >
+          Read only
+        </span>
+      }
+      description={
+        <span
+          style={{
+            fontSize: "14px",
+            color: "#111",
+            lineHeight: "22px",
+          }}
+        >
+          Please contact your instance administrator to get access to edit these
+          settings.
+        </span>
+      }
+      style={{
+        backgroundColor: "#EAF7FF",
+        border: "1px solid #34ADFF",
+        borderLeft: "4px solid #34ADFF",
+        borderRadius: "16px",
+        padding: "12px",
+        display: "flex",
+        alignItems: "flex-start",
+        ...style,
+      }}
+    />
+  );
+};
+
+export default ReadOnlyAlert;

--- a/frontend/src/pages/cases/components/index.js
+++ b/frontend/src/pages/cases/components/index.js
@@ -29,3 +29,4 @@ export { default as IncomeGatingAlert } from "./IncomeGatingAlert";
 export { default as ScenarioModelingIncomeDriversAndChart } from "./ScenarioModelingIncomeDriversAndChart";
 export { default as ScenarioModelingROIForm } from "./ScenarioModelingROIForm";
 export { default as WhatIsNextInfoBox } from "./WhatIsNextInfoBox";
+export { default as ReadOnlyAlert } from "./ReadOnlyAlert";

--- a/frontend/src/pages/cases/steps/UnderstandIncomeGap.js
+++ b/frontend/src/pages/cases/steps/UnderstandIncomeGap.js
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { stepPath, CurrentCaseState } from "../store";
+import { UserState } from "../../../store";
 import { Row, Col, Card, Space } from "antd";
 import {
   ChartIncomeGap,
@@ -15,6 +16,7 @@ import {
   ChartNetIncomePerLandUnit,
 } from "../visualizations";
 import { routePath } from "../../../components/route";
+import { ReadOnlyAlert } from "../components";
 
 /**
  * STEP 3
@@ -27,6 +29,7 @@ const UnderstandIncomeGap = ({
 }) => {
   const navigate = useNavigate();
   const currentCase = CurrentCaseState.useState((s) => s);
+  const { isExternalRegular } = UserState.useState((s) => s);
 
   const backFunction = useCallback(() => {
     navigate(-1);
@@ -69,6 +72,11 @@ const UnderstandIncomeGap = ({
         </Space>
       </Col>
 
+      {isExternalRegular && (
+        <Col span={24}>
+          <ReadOnlyAlert />
+        </Col>
+      )}
       <Col span={24}>
         <Card className="card-section-wrapper">
           Understand current income and the income gap


### PR DESCRIPTION
## What
Added a "Read only" info alert banner for **external regular** users on **Step 1** (Set Income Target) and **Step 3** (Understand Income Gap).

## Why
External regular users have view-only access on certain case pages, but there was no visual indicator explaining why editing controls are disabled. This causes confusion. Resolves **#731**.

## How
- Created a new reusable `ReadOnlyAlert` component styled per the Figma design (light blue `#EAF7FF` background, blue `#34ADFF` left border accent, info icon).
- Integrated conditionally in `Case.js` (Step 1, above `SegmentTabsWrapper`) and `UnderstandIncomeGap.js` (Step 3, above the section card).
- Uses the existing `UserState.isExternalRegular` flag — no new state or API changes.

## Files Changed
| File | Change |
|------|--------|
| `frontend/src/pages/cases/components/ReadOnlyAlert.js` | **NEW** — Reusable alert component |
| `frontend/src/pages/cases/components/index.js` | Added barrel export |
| `frontend/src/pages/cases/Case.js` | Alert above SegmentTabsWrapper in Step 1 |
| `frontend/src/pages/cases/steps/UnderstandIncomeGap.js` | Alert above section card in Step 3 |

## Testing
- ✅ `yarn lint` — 0 errors
- ✅ Manual verification: alert appears only for external regular users on Step 1 and Step 3
- ✅ No alert shown for admin / internal / external advanced users

## Checklist
- [x] Code follows project conventions (Ant Design Alert, pullstate UserState)
- [x] Lint passes cleanly
- [x] No backend changes required
- [x] Documentation aligned

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214921965194965